### PR TITLE
Bump hapi peer dependency to support v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "homepage": "https://github.com/bendrucker/hapi-require-https",
   "devDependencies": {
     "code": "~1.2.0",
-    "hapi": "^9.0.3",
-    "lab": "~5.0.1"
+    "hapi": "^10.0.1",
+    "lab": "~5.10.0"
   },
   "peerDependencies": {
-    "hapi": ">=8 <10"
+    "hapi": ">=8 <11"
   }
 }


### PR DESCRIPTION
As stated in the release notes, Hapi v10 does not contain any breaking changes from v9, so this should be painless. See https://github.com/hapijs/hapi/issues/2764

I took the liberty to also update lab to its most recent version, so the new `Intl` global is not incorrectly reported as a leak when running tests.