### PR TITLE
Adds options for disabling and non-proxy scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
 - '4.0'
+- '6.0'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
 hapi-require-https [![Build Status](https://travis-ci.org/bendrucker/hapi-require-https.svg?branch=master)](https://travis-ci.org/bendrucker/hapi-require-https)
 ==================
 
-http to https redirection for Hapi servers behind a reverse proxy. Any incoming request with `'http'` in `X-Forwarded-Proto` will be redirected (301) to the same host and path with `'https'` as the protocol. 
+http to https redirection for Hapi servers.
+
+For servers behind a reverse proxy or any load balancer setting the `X-Forwarded-Proto` header, such as AWS ELB. Any incoming request with `'http'` in `X-Forwarded-Proto` will be redirected (301) to the same host and path with `'https'` as the protocol.
+
+This plugin can also be used with a normal http connection by setting `proxied: false` in the options. Any request with an `'http'` protocol will be redirected (301) to the same host and path with `'https'` as the protocol. This could be handy if you are trying to save money by not running behind an ELB on AWS for certain environments.
+
+A more efficient option is outlined [here](https://github.com/hapijs/hapi/issues/778#issuecomment-16604734) if the server will never have proxy enabled.
+
+## Installation
+
+```bash
+npm install --save hapi-require-https
+```
 
 ## Usage
 
@@ -12,3 +24,23 @@ server.register(redirect, function (err) {
   console.error(err)
 })
 ```
+
+Optionally, register with custom options. Helpful when used with [Confidence](https://github.com/hapijs/confidence) for different environments or if the connection should always be checked.
+
+```js
+server.register({
+    register: 'hapi-require-https',
+    options: {
+      // custom options
+    }
+  }, function (err) {
+    console.error(err)
+  })
+```
+
+### Options
+
+- `options` - plugin options object where:
+  - `enabled` - a boolean specifying whether to enable. Defaults to `true`
+  - `proxied` - a boolean specifying whether server is behind a reverse proxy.  Defaults to `true`
+  - `shouldRedirect` - a function used to determine whether to redirect. In the crazy event you'd like to override the default functionality.

--- a/index.js
+++ b/index.js
@@ -1,14 +1,34 @@
 'use strict'
 
-exports.register = function (server, options, next) {
-  server.ext('onRequest', function (request, reply) {
-    if (request.headers['x-forwarded-proto'] === 'http') {
-      return reply()
-        .redirect('https://' + request.headers.host + request.url.path)
-        .code(301)
+var internals = {}
+
+internals.defaults = {
+  enabled: true,
+  proxied: true,
+  shouldRedirect: function (config, request) {
+    if (config.proxied) {
+      return request.headers['x-forwarded-proto'] === 'http'
     }
-    reply.continue()
-  })
+
+    return request.server.info.protocol === 'http'
+  }
+}
+
+exports.register = function (server, options, next) {
+  var config = Object.assign({}, internals.defaults, options)
+
+  // don't register unless needed
+  if (config.enabled) {
+    server.ext('onRequest', function (request, reply) {
+      if (config.shouldRedirect(config, request)) {
+        return reply()
+          .redirect('https://' + request.headers.host + request.url.path)
+          .code(301)
+      }
+      reply.continue()
+    })
+  }
+
   next()
 }
 

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   },
   "homepage": "https://github.com/bendrucker/hapi-require-https",
   "devDependencies": {
-    "code": "^1.5.0",
+    "code": "^3.0.1",
     "hapi": "^13.0.0",
-    "lab": "^6.2.0",
-    "standard": "^5.3.1"
+    "lab": "^10.9.0",
+    "standard": "^7.1.2"
   },
   "peerDependencies": {
     "hapi": ">=8 <14"

--- a/test.js
+++ b/test.js
@@ -10,20 +10,35 @@ var expect = Code.expect
 var hapi = require('hapi')
 
 describe('hapi-require-https', function () {
-  var server = new hapi.Server()
-  server.connection()
-  server.register(require('./'), function (err) {
-    if (err) throw err
-  })
-  server.route({
-    method: 'GET',
-    path: '/',
-    handler: function (request, reply) {
-      reply('Hello!')
-    }
-  })
+  function createServer (options) {
+    var config = options || {}
+
+    var server = new hapi.Server()
+
+    server.connection()
+
+    server.register({ register: require('./'), options: config }, function (err) {
+      if (err) throw err
+    })
+
+    server.route({
+      method: 'GET',
+      path: '/',
+      handler: function (request, reply) {
+        reply('Hello!')
+      }
+    })
+
+    return server
+  }
+
+  function destroy (server) {
+    server.stop()
+  }
 
   it('redirects requests where x-forwarded-proto is http', function (done) {
+    var server = createServer()
+
     server.inject({
       url: '/',
       headers: {
@@ -33,11 +48,32 @@ describe('hapi-require-https', function () {
     }, function (response) {
       expect(response.statusCode).to.equal(301)
       expect(response.headers.location).to.equal('https://host/')
+
+      destroy(server)
+      done()
+    })
+  })
+
+  it('redirects requests where protocol is http and proxy is false', function (done) {
+    var server = createServer({ proxied: false })
+
+    server.inject({
+      url: '/',
+      headers: {
+        host: 'host'
+      }
+    }, function (response) {
+      expect(response.statusCode).to.equal(301)
+      expect(response.headers.location).to.equal('https://host/')
+
+      destroy(server)
       done()
     })
   })
 
   it('includes the query string in redirects', function (done) {
+    var server = createServer()
+
     server.inject({
       url: '/?test=test&test2=test2',
       headers: {
@@ -47,11 +83,15 @@ describe('hapi-require-https', function () {
     }, function (response) {
       expect(response.statusCode).to.equal(301)
       expect(response.headers.location).to.equal('https://host/?test=test&test2=test2')
+
+      destroy(server)
       done()
     })
   })
 
   it('ignores all other requests', function (done) {
+    var server = createServer()
+
     server.inject({
       url: '/',
       headers: {
@@ -61,6 +101,26 @@ describe('hapi-require-https', function () {
     }, function (response) {
       expect(response.statusCode).to.equal(200)
       expect(response.result).to.equal('Hello!')
+
+      destroy(server)
+      done()
+    })
+  })
+
+  it('ignores requests when disabled', function (done) {
+    var server = createServer({ enabled: false })
+
+    server.inject({
+      url: '/',
+      headers: {
+        host: 'host',
+        'x-forwarded-proto': 'http'
+      }
+    }, function (response) {
+      expect(response.statusCode).to.equal(200)
+      expect(response.result).to.equal('Hello!')
+
+      destroy(server)
       done()
     })
   })


### PR DESCRIPTION
I needed a little more control for certain scenarios so I added some options discussed in bendrucker/hapi-require-https#1. Namely, I wanted to be able to disable using Confidence and added non-proxy support if people wanted to use that. Someone can also override the default function if the so desire.

I also updated deps to pass on Node 6.

- adds options for disabling and non-proxy scenarios
- updates tests to create/destroy new servers per test to support
setting different options
- updates Travis for Node 6.0
- updates dependencies to pass tests in Node >= 6.0