### PR TITLE
chore(package): update hapi to version 16.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   },
   "homepage": "https://github.com/bendrucker/hapi-require-https",
   "devDependencies": {
-    "hapi": "^15.0.0",
+    "hapi": "^16.0.1",
     "standard": "^8.0.0",
     "tape": "~4.6.0",
     "test-peer-range": "~1.0.1"
   },
   "peerDependencies": {
-    "hapi": ">=8 <16"
+    "hapi": ">=8 <17"
   },
   "files": [
     "*.js"


### PR DESCRIPTION
[Hapi](https://www.npmjs.com/package/hapi) has a new version : 16.0.1 
With some breaking changes : 

```
Upgrade joi to version 10.0.1 which includes two breaking changes.
Upgrade call to version 4.0.0 which changes how empty path parameters are reported. This change includes as empty parameters strings in request.params and request.paramsArray when the path reaches the parameter. For example, /path/ matching /path/{x?} will now include { x: '' } in request.params, but /path will not include x.
```

But both project can be used together because of the peerDependencies asking to be lower than V.16. 
I've updated the devDependencies to be **16.0.1** and the peerDependencies to be **>=8 <17**