### PR TITLE
added support for x-forwarded-host

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ exports.register = function (server, options, next) {
     var redirect = options.proxy !== false
       ? request.headers['x-forwarded-proto'] === 'http'
       : request.connection.info.protocol === 'http'
-    var host = request.headers['x-forwarded-host'] || request.headers.host;
+    var host = request.headers['x-forwarded-host'] || request.headers.host
 
     if (redirect) {
       return reply()

--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@ exports.register = function (server, options, next) {
     var redirect = options.proxy !== false
       ? request.headers['x-forwarded-proto'] === 'http'
       : request.connection.info.protocol === 'http'
+    var host = request.headers['x-forwarded-host'] || request.headers.host;
 
     if (redirect) {
       return reply()
-        .redirect('https://' + request.headers.host + request.url.path)
+        .redirect('https://' + host + request.url.path)
         .code(301)
     }
     reply.continue()

--- a/test.js
+++ b/test.js
@@ -97,6 +97,22 @@ test('multiple connections', function (t) {
   })
 })
 
+test('x-forward-host support', function (t) {
+  t.plan(2)
+
+  Server().inject({
+    url: '/',
+    headers: {
+      host: 'host',
+      'x-forwarded-proto': 'http',
+      'x-forwarded-host': 'host2'
+    }
+  }, function (response) {
+    t.equal(response.statusCode, 301, 'sets 301 code')
+    t.equal(response.headers.location, 'https://host2/', 'sets Location header')
+  })
+})
+
 function Server (options) {
   var server = new hapi.Server()
   server.connection()


### PR DESCRIPTION
we have our node box behind a proxy that is actually on a different host, so we need to use the x-forwarded-host instead of the request host