### PR TITLE
Support hapi v18

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function register (server, options) {
 
     if (!redirect) return h.continue
     return h
-      .redirect('https://' + host + request.url.path)
+      .redirect('https://' + host + (request.url.path || request.url.pathname + request.url.search))
       .takeover()
       .code(301)
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-require-https",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "hapi http -> https redirection",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "test-peer-range": "~1.1.0"
   },
   "peerDependencies": {
-    "hapi": ">=17 <18"
+    "hapi": ">=17 <19"
   },
   "files": [
     "*.js"


### PR DESCRIPTION
v18 addopted node's move to deprecate its `Url.parse()` and `Url.format()` methods
Hapi v18 no longer supports `request.url.path`

See: [https://github.com/hapijs/hapi/issues/3871](https://github.com/hapijs/hapi/issues/3871)